### PR TITLE
Create user in RWS when self registering in usaco style contest

### DIFF
--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -111,6 +111,9 @@ class RegistrationHandler(ContestHandler):
 
         self.sql_session.commit()
 
+        # Create the user in RWS
+        self.service.proxy_service.reinitialize()
+
         self.finish(user.username)
 
     @multi_contest


### PR DESCRIPTION
Currently when a user registers in a usaco style contest, RankingWebServer is not updated leading to the user not being displayed. Also every time the user makes a submission an error is generated when trying to send the submission to RWS because the user does not exist in the ranking.