### PR TITLE
Customizable documentation

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -214,6 +214,7 @@ class Config:
         self.max_submission_length = 100_000  # 100 KB
         self.max_input_length = 5_000_000  # 5 MB
         self.stl_path = "/usr/share/cppreference/doc/html/"
+        self.docs_path = None
         # Prefix of 'shared-mime-info'[1] installation. It can be found
         # out using `pkg-config --variable=prefix shared-mime-info`, but
         # it's almost universally the same (i.e. '/usr') so it's hardly

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -31,6 +31,7 @@
 import ipaddress
 import json
 import logging
+import os.path
 import re
 
 try:
@@ -41,6 +42,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from cms import config
 from cms.db import PrintJob, User, Participation, Team
+from cms.grading.languagemanager import get_language
 from cms.grading.steps import COMPILATION_MESSAGES, EVALUATION_MESSAGES
 from cms.server import multi_contest
 from cms.server.contest.authentication import validate_login
@@ -363,7 +365,21 @@ class DocumentationHandler(ContestHandler):
     @tornado_web.authenticated
     @multi_contest
     def get(self):
+        contest = self.r_params.get("contest")
+        languages = [get_language(lang) for lang in contest.languages]
+
+        language_docs = []
+        if config.docs_path is not None:
+            for language in languages:
+                ext = language.source_extensions[0][1:] # remove dot
+                path = os.path.join(config.docs_path, ext)
+                if os.path.exists(path):
+                    language_docs.append((language.name, f"./docs/{ext}/index.html"))
+        else:
+            language_docs.append(("C++", "./docs/en/index.html"))
+
         self.render("documentation.html",
                     COMPILATION_MESSAGES=COMPILATION_MESSAGES,
                     EVALUATION_MESSAGES=EVALUATION_MESSAGES,
+                    language_docs=language_docs,
                     **self.r_params)

--- a/cms/server/contest/server.py
+++ b/cms/server/contest/server.py
@@ -105,7 +105,7 @@ class ContestWebServer(WebService):
             listen_address=listen_address)
 
         self.wsgi_app = SharedDataMiddleware(
-            self.wsgi_app, {"/stl": config.stl_path},
+            self.wsgi_app, {"/docs": config.docs_path or config.stl_path},
             cache=True, cache_timeout=SECONDS_IN_A_YEAR,
             fallback_mimetype="application/octet-stream")
 

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -11,11 +11,10 @@
 
 <h2>{% trans %}Programming languages and libraries{% endtrans %}</h2>
 
-{% if contest.languages|map("to_language")|map(attribute="source_extensions")|any("contains", ".cpp") %}
-<h3>C++</h3>
-
-<p><a href="{{ url("stl", "en", "index.html") }}">{% trans %}Standard Template Library{% endtrans %}</a></p>
-{% endif %}
+{% for name, path in language_docs %}
+<h3>{{name}}</h3>
+<p><a href="{{ path }}">{% trans %}Documentation{% endtrans %}</a></p>
+{% endfor %}
 
 {% if contest.languages|map("to_language")|map(attribute="source_extensions")|any("contains", ".java") %}
 <h3>Java</h3>

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -154,8 +154,10 @@
     "max_submission_length": 100000,
     "max_input_length": 5000000,
 
-    // STL documentation path in the system (exposed in CWS).
-    "stl_path": "/usr/share/cppreference/doc/html/",
+    // Path to the documentation exposed by CWS. To show a documentation
+    // link add a folder for each language with index.html inside. For
+    // example for C++ add "cpp/index.html", for Java "java/index.html".
+    "docs_path": "/usr/share/cms/docs",
 
     // Telegram bot configuration for posting notifications for the
     // questions. The token is a string obtained from @BotFather and


### PR DESCRIPTION
Adds support for documentation of multiple languages.
When `docs_path` is provided cms searches the directory for documentation otherwise fallbacks to the `stl_path`.