### PR TITLE
Add support for importing score_precision in italian_yaml

### DIFF
--- a/cmscontrib/loaders/italy_yaml.py
+++ b/cmscontrib/loaders/italy_yaml.py
@@ -471,6 +471,9 @@ class YamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
                     "Attachment %s for task %s" % (filename, name))
                 args["attachments"][filename] = Attachment(filename, digest)
 
+        # Score precision.
+        load(conf, args, "score_precision")
+
         task = Task(**args)
 
         args = {}


### PR DESCRIPTION
This is already merged in cms-dev/cms, it would be useful to have it.